### PR TITLE
FIX: fix link error when LIVE555_MONOLITH_BUILD is ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,20 +283,38 @@ endif()
 if(LIVE555_MONOLITH_BUILD)
    message(STATUS "Shared library")
    
-    add_library(live555 SHARED 
-        $<TARGET_OBJECTS:UsageEnvironment> 
-        $<TARGET_OBJECTS:groupsock>
-        $<TARGET_OBJECTS:BasicUsageEnvironment>
-        $<TARGET_OBJECTS:liveMedia>
-        $<TARGET_OBJECTS:EpollTaskScheduler>
-    )
-    target_include_directories(live555 INTERFACE
-        $<BUILD_INTERFACE:${live555_SOURCE_DIR}/UsageEnvironment/include>
-        $<BUILD_INTERFACE:${live555_SOURCE_DIR}/groupsock/include>
-        $<BUILD_INTERFACE:${live555_SOURCE_DIR}/BasicUsageEnvironment/include>
-        $<BUILD_INTERFACE:${live555_SOURCE_DIR}/liveMedia/include>
-        $<BUILD_INTERFACE:${live555_SOURCE_DIR}/EpollTaskScheduler/include>
-    )
+
+   if(TARGET EpollTaskScheduler)
+      add_library(live555 SHARED
+         $<TARGET_OBJECTS:UsageEnvironment>
+         $<TARGET_OBJECTS:groupsock>
+         $<TARGET_OBJECTS:BasicUsageEnvironment>
+         $<TARGET_OBJECTS:liveMedia>
+         $<TARGET_OBJECTS:EpollTaskScheduler>
+      )
+      target_include_directories(live555 INTERFACE
+         $<BUILD_INTERFACE:${live555_SOURCE_DIR}/UsageEnvironment/include>
+         $<BUILD_INTERFACE:${live555_SOURCE_DIR}/groupsock/include>
+         $<BUILD_INTERFACE:${live555_SOURCE_DIR}/BasicUsageEnvironment/include>
+         $<BUILD_INTERFACE:${live555_SOURCE_DIR}/liveMedia/include>
+         $<BUILD_INTERFACE:${live555_SOURCE_DIR}/EpollTaskScheduler/include>
+      )
+      add_library(live555::EpollTaskScheduler ALIAS live555)
+   else()
+      add_library(live555 SHARED
+         $<TARGET_OBJECTS:UsageEnvironment>
+         $<TARGET_OBJECTS:groupsock>
+         $<TARGET_OBJECTS:BasicUsageEnvironment>
+         $<TARGET_OBJECTS:liveMedia>
+      )
+      target_include_directories(live555 INTERFACE
+         $<BUILD_INTERFACE:${live555_SOURCE_DIR}/UsageEnvironment/include>
+         $<BUILD_INTERFACE:${live555_SOURCE_DIR}/groupsock/include>
+         $<BUILD_INTERFACE:${live555_SOURCE_DIR}/BasicUsageEnvironment/include>
+         $<BUILD_INTERFACE:${live555_SOURCE_DIR}/liveMedia/include>
+      )
+   endif()
+
     if(MSVC)
         target_link_libraries(live555 PUBLIC ws2_32)
     endif()
@@ -307,13 +325,6 @@ if(LIVE555_MONOLITH_BUILD)
       )
       set(LIB_EXTENSION ".dll")
    endif ()
-   if(TARGET EpollTaskScheduler)
-      target_link_libraries(live555 INTERFACE
-          $<TARGET_OBJECTS:EpollTaskScheduler>)
-      target_include_directories(live555 INTERFACE
-          $<BUILD_INTERFACE:${live555_SOURCE_DIR}/EpollTaskScheduler/include>)
-      add_library(live555::EpollTaskScheduler ALIAS EpollTaskScheduler)
-   endif()
    if(LIVE555_ENABLE_OPENSSL)
       message(STATUS "find package OpenSSL.")
       find_package(OpenSSL REQUIRED COMPONENTS Crypto SSL)


### PR DESCRIPTION
### KO
cmake 프로젝트로 관리 해주시고 계셔서 감사합니다. 
윈도우즈 에서 LIVE555_MONOLITH_BUILD을 ON으로 설정시 링크 에러가 발생하여 수정후 풀리퀘스트 드립니다.

현재 LIVE555_MONOLITH_BUILD을 ON으로 설정하면 live555를 의존성으로 추가한 cmake 프로젝트에 EpollTaskScheduler.obj와 live555.dll가 동시에 링크 됩니다. 이로 인해 정의가 중복되어 링크 에러가 발생하였습니다.

EpollTaskScheduler 정의가 중복되므로 target_link_libraries 구문을 제거하고 if (Target EpollTaskScheduler) 구문을 이용해 add_library에 EpollTaskScheduler가 포함되거나 포함되지 않도록 변경하였습니다.

아래 코드로 새 cmake 프로젝트를 만들고 재현해 볼 수 있습니다.

### EN (translated by ChatGPT)
Thank you for managing the project with CMake.
When the LIVE555_MONOLITH_BUILD option is set to ON on Windows, a linking error occurs. I have fixed this and am submitting a pull request.

Currently, when LIVE555_MONOLITH_BUILD is set to ON, both EpollTaskScheduler.obj and live555.dll are linked simultaneously in a CMake project that depends on live555. This causes a linking error due to duplicate definitions.

To resolve this, I removed the target_link_libraries statement for EpollTaskScheduler and modified the code to use the if (Target EpollTaskScheduler) statement. This ensures that EpollTaskScheduler is included or excluded from add_library accordingly.

You can reproduce the issue with make new cmake project and use following code:

### reproducible code
use cpm 
```cmake
CPMAddPackage(
    NAME live555
    GITHUB_REPOSITORY melchi45/live555
    GIT_TAG master
    OPTIONS "LIVE555_MONOLITH_BUILD ON" "LIVE555_BUILD_EXAMPLES OFF" 
)

add_library(foo STATIC main.cpp)
target_link_libraries(foo PUBLIC live555::live555)
```
or use fetch content 
```cmake
include(FetchContent)
FetchContent_Declare(
    live555
    GIT_REPOSITORY https://github.com/melchi45/live555.git
    GIT_TAG master
)
set(LIVE555_MONOLITH_BUILD ON CACHE INTERNAL "Build SHARED libraries")
FetchContent_MakeAvailable(live555)

add_library(foo STATIC main.cpp)
target_link_libraries(foo PUBLIC live555::live555)
```